### PR TITLE
delete trailing slash on auth server url

### DIFF
--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -9,6 +9,9 @@ module.exports = (app) => {
   if (KEYCLOAK_CONFIG) {
     log.info('KEYCLOAK_CONFIG was detected. Enabling keycloak protections.')
     log.debug('KEYCLOAK_CONFIG was set to: %j', KEYCLOAK_CONFIG)
+    // Keycloak 7.4 seems to have appended a trailing slash to this value which upsets keycloak-connect,
+    // this removes any trailing slashes
+    KEYCLOAK_CONFIG['auth-server-url'] = KEYCLOAK_CONFIG['auth-server-url'].replace(/\/$/, "")
     const store = new session.MemoryStore()
     const keycloak = new Keycloak({ store }, KEYCLOAK_CONFIG)
 


### PR DESCRIPTION
@aidenkeating @evanshortiss RHSSO 7.4 seems to have introduced a trailing slash on the auth-server-url that breaks this app. This PR should fix it. Though I'm not certain how to test it with podman (can't install s2i).